### PR TITLE
fix dlcli set  with empty settingsfile

### DIFF
--- a/dlcli/cli/cli.py
+++ b/dlcli/cli/cli.py
@@ -85,7 +85,7 @@ def cli(settingsfile, url, org, account, key, backupdir, loglevel, debug):
         if value:
             context.settings[arg] = value
 
-    if len(context.settings['key']) != 204:
+    if (context.settings['key']) and (len(context.settings['key']) != 204):
         print "Not a valid key! Please generate an API token at https://app.dataloop.io/#/user-account/api-tokens"
         sys.exit(2)
 


### PR DESCRIPTION
dlcli set  fails if settings file is empty or doesn't contain key variable.
it was introduced in 0.4.8.

Typically, I do 3 commands to create settings file:
$ dlcli --settingsfile set org acme
$ dlcli --settingsfile set account foo
$ dlcli --settingsfile set key long_hash

$ dlcli set org acme
Traceback (most recent call last):
  File "/usr/local/bin/dlcli", line 9, in <module>
    load_entry_point('dlcli==0.4.8', 'console_scripts', 'dlcli')()
  File "/usr/local/lib/python2.7/dist-packages/dlcli/dlcli.py", line 5, in main
    cli(obj={"filters": []})
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 716, in **call**
    return self.main(_args, *_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1057, in invoke
    Command.invoke(self, ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, *_ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
    return callback(_args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/dlcli/cli/cli.py", line 88, in cli
    if len(context.settings['key']) != 204:
TypeError: object of type 'NoneType' has no len()
